### PR TITLE
Fix enable_4bit_background()

### DIFF
--- a/catalog/vgautil.h
+++ b/catalog/vgautil.h
@@ -143,24 +143,13 @@ enable_4bit_background()
         case DISPLAY_ADAPTER_CGA:
             {
                 // http://www.techhelpmanual.com/901-color_graphics_adapter_i_o_ports.html
-                // Mirrored by BIOS at 0040:0064, which is also updated first
+                // Mirrored by BIOS at 0040:0065, which is also updated first
                 uint8_t far *mode_select_register = (uint8_t far *)0x00400065ul;
                 *mode_select_register &= ~(1<<5);
                 outp(0x3d8, *mode_select_register);
             }
             break;
         case DISPLAY_ADAPTER_EGA:
-            {
-                // TODO: Is this mirrored by the BIOS?
-                uint8_t tmp = inp(0x03da);
-                outp(0x03c0, 0x10);
-                tmp = inp(0x03c1);
-                tmp &= ~(1<<3);
-                // FIXME: Masking the bit in tmp doesn't work,
-                // so we just set it to zero (tested in DOSBox)
-                outp(0x03c0, 0);
-            }
-            break;
         case DISPLAY_ADAPTER_VGA:
             {
                 union REGS regs;
@@ -169,6 +158,7 @@ enable_4bit_background()
                 regs.h.ah = 0x10;
                 regs.h.al = 0x03;
                 regs.h.bl = 0x00;
+                regs.h.bh = 0x00;
 
                 int86(0x10, &regs, &regs);
             }


### PR DESCRIPTION
Closes #1

For some weird reason 86Box's EGA emulation is still annoyingly VGA, and the attribute controller address/data flip-flop may need some more research as to whether it resets when you write or if one needs to read 0x3DA/0x3BA first. Anyway, the BIOS call exists, so we're using that.

And a caveat: According to RBIL, at least one of the ATI EGA Wonder cards will detect as a VGA under this method, at least under certain undocumented configurations. Seems the standard configuration in 86Box for the ATI EGA Wonder 800+ card detects it as an EGA, though, and it's supposed to be a BIOS-level thing, so unless someone reports it as misdetected as VGA on one of the various "Super EGA" cards then it's probably best to leave the detection as-is.